### PR TITLE
feat: PMKIT-015 & PMKIT-016 - Add context Pydantic models with confidence scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,22 @@ All notable changes to PM-Kit are documented in this file.
 - Verified retry behavior with exponential backoff (rate limit, connection, timeout)
 - Added cache hit/miss scenario tests (5 cache-specific tests)
 - Validated error handling for authentication, timeout, and rate limit errors
+
+#### PMKIT-015: Define context Pydantic models
+- Created lean, PM-focused context models (CompanyContext, ProductContext, MarketContext, TeamContext, OKRContext)
+- Implemented smart defaults and B2B/B2C differentiation logic
+- Added validation rules for required fields without overengineering
+- Used Pydantic V2 best practices (ConfigDict, field_validator, model_dump)
+- Created comprehensive test suite with 22 tests covering all models
+- Models focus on essential fields that directly improve PRD quality or save PM time
+
+#### PMKIT-016: Complete team and OKR models with confidence scoring
+- Added confidence scoring (0-100%) to KeyResult model for tracking achievement probability
+- Implemented average_confidence property on Objective to aggregate KR confidence
+- Added at_risk_key_results property to OKRContext to identify KRs with <50% confidence
+- Created tests for confidence validation and at-risk identification
+- All 23 context model tests passing with confidence scoring features
+- Kept implementation minimal - just one new field and two helper properties
 - Implemented proper mocking for OpenAI API responses and streaming
 - All tests passing with 100% coverage of integration scenarios
 - Total project test count: 221 tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,3 +221,4 @@ If cache isn't invalidating properly:
 - always update the CHANGELOG.md after finishing work. Commit after testing.
 - never cheat on tests and make them pass by rewriting the tests or writing the test in a way it always passes.
 - latest Openai model is GPT-5 that was released in August 2025
+- overall implementation plan is in IMP_Claud.md . But over the cousersew of implemntation we may have made some minor changes

--- a/src/pmkit/context/__init__.py
+++ b/src/pmkit/context/__init__.py
@@ -1,1 +1,23 @@
-# Context package
+"""Context module for PM-Kit."""
+
+from .models import (
+    CompanyContext,
+    Context,
+    KeyResult,
+    MarketContext,
+    OKRContext,
+    Objective,
+    ProductContext,
+    TeamContext,
+)
+
+__all__ = [
+    "CompanyContext",
+    "Context",
+    "KeyResult",
+    "MarketContext",
+    "OKRContext",
+    "Objective",
+    "ProductContext",
+    "TeamContext",
+]

--- a/src/pmkit/context/models.py
+++ b/src/pmkit/context/models.py
@@ -1,0 +1,198 @@
+"""Context models for PM-Kit.
+
+Lean, PM-focused models that capture just enough context to generate
+quality PRDs without enterprise theater.
+"""
+
+from typing import Dict, List, Literal, Optional
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class CompanyContext(BaseModel):
+    """Company context - the essentials only."""
+    
+    # Required fields - can't generate good PRDs without these
+    name: str = Field(..., min_length=2, max_length=100, description="Company name")
+    type: Literal["b2b", "b2c", "b2b2c"] = Field(..., description="Business model type")
+    stage: Literal["idea", "seed", "growth", "mature"] = Field(..., description="Company stage")
+    
+    # Smart defaults - inferred or optional
+    domain: Optional[str] = Field(None, description="Company website domain")
+    description: Optional[str] = Field(None, max_length=200, description="One-line description")
+    target_market: Optional[str] = Field(None, description="Primary target market (e.g., SMBs, Enterprise)")
+    
+    @property
+    def is_b2b(self) -> bool:
+        """Check if company is B2B focused."""
+        return self.type in ["b2b", "b2b2c"]
+    
+    @property
+    def is_b2c(self) -> bool:
+        """Check if company is B2C focused."""
+        return self.type in ["b2c", "b2b2c"]
+    
+    @property
+    def needs_compliance(self) -> bool:
+        """Check if company likely needs compliance features."""
+        return self.is_b2b and self.stage in ["growth", "mature"]
+    
+    model_config = ConfigDict(use_enum_values=True)
+
+
+class ProductContext(BaseModel):
+    """Product context - what PMs actually use daily."""
+    
+    # Required fields
+    name: str = Field(..., min_length=1, max_length=100, description="Product name")
+    description: str = Field(..., min_length=10, max_length=500, description="Product description (1-2 sentences)")
+    
+    # Smart defaults
+    stage: Literal["concept", "mvp", "pmf", "scale"] = Field("mvp", description="Product stage")
+    users: Optional[int] = Field(None, ge=0, description="Current users/customers")
+    pricing_model: Optional[str] = Field(None, description="Pricing model (e.g., freemium, subscription)")
+    main_metric: Optional[str] = Field(None, description="North star metric")
+    
+    @field_validator('main_metric', mode='before')
+    @classmethod
+    def set_default_metric(cls, v, info):
+        """Set smart default metric based on context."""
+        if v is None and info.data.get('stage') in ['pmf', 'scale']:
+            # Only suggest defaults for more mature products
+            return None  # Will be set based on company type later
+        return v
+    
+    model_config = ConfigDict(use_enum_values=True)
+
+
+class MarketContext(BaseModel):
+    """Market context - just enough market intelligence."""
+    
+    # All optional but useful
+    competitors: List[str] = Field(default_factory=list, max_length=20, description="Competitor names")
+    market_size: Optional[str] = Field(None, description="TAM/SAM/SOM if known")
+    differentiator: Optional[str] = Field(None, max_length=200, description="Unique value proposition (one-liner)")
+    
+    @property
+    def has_competitors(self) -> bool:
+        """Check if competitors are defined."""
+        return len(self.competitors) > 0
+    
+    @field_validator('competitors')
+    @classmethod
+    def validate_competitors(cls, v):
+        """Ensure competitor names are reasonable."""
+        return [name[:100] for name in v if name.strip()]  # Truncate long names
+
+
+class TeamContext(BaseModel):
+    """Team context - minimal but useful."""
+    
+    size: Optional[int] = Field(None, ge=1, le=10000, description="Total team size")
+    roles: Dict[str, int] = Field(
+        default_factory=dict, 
+        description="Role distribution (e.g., {'engineers': 5, 'designers': 1})"
+    )
+    
+    @property
+    def total_size(self) -> int:
+        """Calculate total team size from roles if not explicitly set."""
+        if self.size:
+            return self.size
+        return sum(self.roles.values())
+    
+    @property
+    def is_engineering_heavy(self) -> bool:
+        """Check if team is engineering-heavy (useful for technical PRDs)."""
+        eng_count = self.roles.get('engineers', 0) + self.roles.get('developers', 0)
+        total = self.total_size
+        return eng_count / total > 0.5 if total > 0 else False
+
+
+class KeyResult(BaseModel):
+    """Individual key result."""
+    
+    description: str = Field(..., min_length=5, max_length=200)
+    target_value: Optional[str] = Field(None, description="Target metric value")
+    current_value: Optional[str] = Field(None, description="Current metric value")
+    confidence: Optional[int] = Field(None, ge=0, le=100, description="Confidence % of achieving target by quarter end")
+
+
+class Objective(BaseModel):
+    """Objective with key results."""
+    
+    title: str = Field(..., min_length=5, max_length=200, description="Objective title")
+    key_results: List[KeyResult] = Field(default_factory=list, max_length=5)
+    
+    @field_validator('key_results')
+    @classmethod
+    def validate_key_results(cls, v):
+        """Ensure at least one key result per objective."""
+        if len(v) == 0:
+            # Allow empty for initial setup
+            return v
+        return v
+    
+    @property
+    def average_confidence(self) -> Optional[float]:
+        """Get average confidence across all key results."""
+        confidences = [kr.confidence for kr in self.key_results if kr.confidence is not None]
+        return sum(confidences) / len(confidences) if confidences else None
+
+
+class OKRContext(BaseModel):
+    """OKR context - current objectives and key results."""
+    
+    objectives: List[Objective] = Field(default_factory=list, max_length=10)
+    quarter: Optional[str] = Field(None, description="Current quarter (e.g., Q1 2025)")
+    
+    @property
+    def has_okrs(self) -> bool:
+        """Check if OKRs are defined."""
+        return len(self.objectives) > 0
+    
+    @property
+    def total_key_results(self) -> int:
+        """Count total key results across all objectives."""
+        return sum(len(obj.key_results) for obj in self.objectives)
+    
+    @property
+    def at_risk_key_results(self) -> List[KeyResult]:
+        """Get key results with low confidence (<50%)."""
+        return [
+            kr for obj in self.objectives 
+            for kr in obj.key_results 
+            if kr.confidence is not None and kr.confidence < 50
+        ]
+
+
+class Context(BaseModel):
+    """Complete context combining all aspects."""
+    
+    company: CompanyContext
+    product: ProductContext
+    market: Optional[MarketContext] = None
+    team: Optional[TeamContext] = None
+    okrs: Optional[OKRContext] = None
+    
+    @property
+    def is_b2b(self) -> bool:
+        """Convenience property for B2B check."""
+        return self.company.is_b2b
+    
+    @property
+    def is_b2c(self) -> bool:
+        """Convenience property for B2C check."""
+        return self.company.is_b2c
+    
+    def get_default_metric(self) -> str:
+        """Get smart default metric based on company type."""
+        if self.is_b2b:
+            return "MRR"  # Monthly Recurring Revenue
+        else:
+            return "MAU"  # Monthly Active Users
+    
+    def to_yaml_dict(self) -> dict:
+        """Convert to YAML-friendly dictionary."""
+        return self.model_dump(exclude_none=True, exclude_unset=True)
+    
+    model_config = ConfigDict(use_enum_values=True)

--- a/tests/test_context_models.py
+++ b/tests/test_context_models.py
@@ -1,0 +1,445 @@
+"""Tests for context models."""
+
+import pytest
+from pydantic import ValidationError
+
+from pmkit.context.models import (
+    CompanyContext,
+    ProductContext,
+    MarketContext,
+    TeamContext,
+    KeyResult,
+    Objective,
+    OKRContext,
+    Context,
+)
+
+
+class TestCompanyContext:
+    """Test CompanyContext model."""
+    
+    def test_minimal_valid_company(self):
+        """Test creating company with minimal required fields."""
+        company = CompanyContext(
+            name="Acme Corp",
+            type="b2b",
+            stage="seed"
+        )
+        assert company.name == "Acme Corp"
+        assert company.type == "b2b"
+        assert company.stage == "seed"
+        assert company.domain is None
+        assert company.description is None
+    
+    def test_company_with_all_fields(self):
+        """Test creating company with all fields."""
+        company = CompanyContext(
+            name="Acme Corp",
+            type="b2b",
+            stage="growth",
+            domain="acme.com",
+            description="Leading B2B SaaS platform",
+            target_market="Enterprise"
+        )
+        assert company.domain == "acme.com"
+        assert company.description == "Leading B2B SaaS platform"
+        assert company.target_market == "Enterprise"
+    
+    def test_b2b_properties(self):
+        """Test B2B-related properties."""
+        b2b_company = CompanyContext(name="B2B Co", type="b2b", stage="growth")
+        assert b2b_company.is_b2b is True
+        assert b2b_company.is_b2c is False
+        assert b2b_company.needs_compliance is True
+        
+        b2c_company = CompanyContext(name="B2C Co", type="b2c", stage="growth")
+        assert b2c_company.is_b2b is False
+        assert b2c_company.is_b2c is True
+        assert b2c_company.needs_compliance is False
+        
+        b2b2c_company = CompanyContext(name="B2B2C Co", type="b2b2c", stage="seed")
+        assert b2b2c_company.is_b2b is True
+        assert b2b2c_company.is_b2c is True
+        assert b2b2c_company.needs_compliance is False  # Not in growth/mature
+    
+    def test_company_validation(self):
+        """Test company field validation."""
+        # Name too short
+        with pytest.raises(ValidationError):
+            CompanyContext(name="A", type="b2b", stage="seed")
+        
+        # Name too long
+        with pytest.raises(ValidationError):
+            CompanyContext(name="A" * 101, type="b2b", stage="seed")
+        
+        # Invalid type
+        with pytest.raises(ValidationError):
+            CompanyContext(name="Test Co", type="invalid", stage="seed")
+        
+        # Invalid stage
+        with pytest.raises(ValidationError):
+            CompanyContext(name="Test Co", type="b2b", stage="invalid")
+
+
+class TestProductContext:
+    """Test ProductContext model."""
+    
+    def test_minimal_valid_product(self):
+        """Test creating product with minimal required fields."""
+        product = ProductContext(
+            name="Awesome Product",
+            description="A tool that helps teams collaborate better"
+        )
+        assert product.name == "Awesome Product"
+        assert product.description == "A tool that helps teams collaborate better"
+        assert product.stage == "mvp"  # Default
+        assert product.users is None
+        assert product.pricing_model is None
+    
+    def test_product_with_all_fields(self):
+        """Test creating product with all fields."""
+        product = ProductContext(
+            name="Pro Tool",
+            description="Enterprise collaboration platform",
+            stage="scale",
+            users=10000,
+            pricing_model="subscription",
+            main_metric="MRR"
+        )
+        assert product.stage == "scale"
+        assert product.users == 10000
+        assert product.pricing_model == "subscription"
+        assert product.main_metric == "MRR"
+    
+    def test_product_validation(self):
+        """Test product field validation."""
+        # Name empty
+        with pytest.raises(ValidationError):
+            ProductContext(name="", description="Valid description")
+        
+        # Description too short
+        with pytest.raises(ValidationError):
+            ProductContext(name="Product", description="Short")
+        
+        # Description too long
+        with pytest.raises(ValidationError):
+            ProductContext(name="Product", description="A" * 501)
+        
+        # Negative users
+        with pytest.raises(ValidationError):
+            ProductContext(
+                name="Product",
+                description="Valid description here",
+                users=-1
+            )
+
+
+class TestMarketContext:
+    """Test MarketContext model."""
+    
+    def test_empty_market_context(self):
+        """Test creating empty market context."""
+        market = MarketContext()
+        assert market.competitors == []
+        assert market.market_size is None
+        assert market.differentiator is None
+        assert market.has_competitors is False
+    
+    def test_market_with_competitors(self):
+        """Test market with competitors."""
+        market = MarketContext(
+            competitors=["Slack", "Teams", "Discord"],
+            market_size="$10B TAM",
+            differentiator="AI-powered insights"
+        )
+        assert len(market.competitors) == 3
+        assert market.has_competitors is True
+        assert market.market_size == "$10B TAM"
+        assert market.differentiator == "AI-powered insights"
+    
+    def test_competitor_validation(self):
+        """Test competitor list validation."""
+        # Too many competitors
+        with pytest.raises(ValidationError):
+            MarketContext(competitors=["Company" + str(i) for i in range(21)])
+        
+        # Long competitor names get truncated
+        long_name = "A" * 150
+        market = MarketContext(competitors=[long_name])
+        assert len(market.competitors[0]) == 100
+        
+        # Empty strings get filtered
+        market = MarketContext(competitors=["Valid", "", "  ", "Another"])
+        assert len(market.competitors) == 2
+
+
+class TestTeamContext:
+    """Test TeamContext model."""
+    
+    def test_empty_team_context(self):
+        """Test creating empty team context."""
+        team = TeamContext()
+        assert team.size is None
+        assert team.roles == {}
+        assert team.total_size == 0
+        assert team.is_engineering_heavy is False
+    
+    def test_team_with_size(self):
+        """Test team with explicit size."""
+        team = TeamContext(size=50)
+        assert team.size == 50
+        assert team.total_size == 50
+    
+    def test_team_with_roles(self):
+        """Test team with role distribution."""
+        team = TeamContext(
+            roles={
+                "engineers": 10,
+                "designers": 2,
+                "pm": 1,
+                "marketing": 3
+            }
+        )
+        assert team.total_size == 16
+        assert team.is_engineering_heavy is True
+        
+        # Non-engineering heavy team
+        team2 = TeamContext(
+            roles={
+                "engineers": 2,
+                "sales": 10,
+                "marketing": 5
+            }
+        )
+        assert team2.is_engineering_heavy is False
+    
+    def test_team_validation(self):
+        """Test team field validation."""
+        # Size too small
+        with pytest.raises(ValidationError):
+            TeamContext(size=0)
+        
+        # Size too large
+        with pytest.raises(ValidationError):
+            TeamContext(size=10001)
+
+
+class TestOKRContext:
+    """Test OKR context models."""
+    
+    def test_empty_okr_context(self):
+        """Test creating empty OKR context."""
+        okrs = OKRContext()
+        assert okrs.objectives == []
+        assert okrs.quarter is None
+        assert okrs.has_okrs is False
+        assert okrs.total_key_results == 0
+    
+    def test_okr_with_objectives(self):
+        """Test OKR with objectives and key results."""
+        kr1 = KeyResult(
+            description="Increase MRR to $100K",
+            target_value="$100K",
+            current_value="$75K"
+        )
+        kr2 = KeyResult(
+            description="Achieve 95% customer retention"
+        )
+        
+        obj = Objective(
+            title="Achieve product-market fit",
+            key_results=[kr1, kr2]
+        )
+        
+        okrs = OKRContext(
+            objectives=[obj],
+            quarter="Q1 2025"
+        )
+        
+        assert okrs.has_okrs is True
+        assert okrs.total_key_results == 2
+        assert okrs.quarter == "Q1 2025"
+    
+    def test_objective_validation(self):
+        """Test objective validation."""
+        # Title too short
+        with pytest.raises(ValidationError):
+            Objective(title="Bad")
+        
+        # Too many key results
+        with pytest.raises(ValidationError):
+            krs = [KeyResult(description=f"KR {i}") for i in range(6)]
+            Objective(title="Valid objective", key_results=krs)
+    
+    def test_key_result_validation(self):
+        """Test key result validation."""
+        # Description too short
+        with pytest.raises(ValidationError):
+            KeyResult(description="Bad")
+        
+        # Description too long
+        with pytest.raises(ValidationError):
+            KeyResult(description="A" * 201)
+        
+        # Confidence out of range (negative)
+        with pytest.raises(ValidationError):
+            KeyResult(description="Valid KR", confidence=-1)
+        
+        # Confidence out of range (>100)
+        with pytest.raises(ValidationError):
+            KeyResult(description="Valid KR", confidence=101)
+    
+    def test_confidence_scoring(self):
+        """Test confidence scoring features."""
+        # Key result with confidence
+        kr1 = KeyResult(
+            description="Increase MRR to $100K",
+            target_value="$100K",
+            current_value="$75K",
+            confidence=70
+        )
+        kr2 = KeyResult(
+            description="Launch enterprise SSO",
+            target_value="Shipped",
+            current_value="In dev",
+            confidence=40  # At risk
+        )
+        kr3 = KeyResult(
+            description="Achieve 95% uptime",
+            target_value="95%",
+            current_value="92%",
+            confidence=85
+        )
+        kr4 = KeyResult(
+            description="Complete user research",
+            target_value="20 interviews",
+            current_value="5 interviews"
+            # No confidence set
+        )
+        
+        obj1 = Objective(
+            title="Q1 Growth targets",
+            key_results=[kr1, kr2, kr3]
+        )
+        obj2 = Objective(
+            title="User insights",
+            key_results=[kr4]
+        )
+        
+        # Test average confidence at objective level
+        assert obj1.average_confidence == (70 + 40 + 85) / 3
+        assert obj2.average_confidence is None  # No confidence set
+        
+        # Test at-risk key results
+        okrs = OKRContext(
+            objectives=[obj1, obj2],
+            quarter="Q1 2025"
+        )
+        
+        at_risk = okrs.at_risk_key_results
+        assert len(at_risk) == 1
+        assert at_risk[0].description == "Launch enterprise SSO"
+        assert at_risk[0].confidence == 40
+
+
+class TestContext:
+    """Test complete Context model."""
+    
+    def test_minimal_context(self):
+        """Test creating context with minimal required fields."""
+        context = Context(
+            company=CompanyContext(
+                name="Test Co",
+                type="b2b",
+                stage="seed"
+            ),
+            product=ProductContext(
+                name="Test Product",
+                description="A great product for testing"
+            )
+        )
+        
+        assert context.is_b2b is True
+        assert context.is_b2c is False
+        assert context.market is None
+        assert context.team is None
+        assert context.okrs is None
+    
+    def test_full_context(self):
+        """Test creating context with all components."""
+        context = Context(
+            company=CompanyContext(
+                name="Full Co",
+                type="b2c",
+                stage="growth"
+            ),
+            product=ProductContext(
+                name="Consumer App",
+                description="Mobile app for consumers"
+            ),
+            market=MarketContext(
+                competitors=["App1", "App2"],
+                market_size="$1B"
+            ),
+            team=TeamContext(
+                size=20,
+                roles={"engineers": 12, "designers": 3}
+            ),
+            okrs=OKRContext(
+                objectives=[
+                    Objective(
+                        title="Reach 1M users",
+                        key_results=[
+                            KeyResult(description="Launch in 3 new markets")
+                        ]
+                    )
+                ]
+            )
+        )
+        
+        assert context.is_b2c is True
+        assert context.market.has_competitors is True
+        assert context.team.total_size == 20
+        assert context.okrs.has_okrs is True
+    
+    def test_default_metric(self):
+        """Test smart default metric based on company type."""
+        b2b_context = Context(
+            company=CompanyContext(name="B2B", type="b2b", stage="growth"),
+            product=ProductContext(name="Product", description="B2B product")
+        )
+        assert b2b_context.get_default_metric() == "MRR"
+        
+        b2c_context = Context(
+            company=CompanyContext(name="B2C", type="b2c", stage="growth"),
+            product=ProductContext(name="Product", description="B2C product")
+        )
+        assert b2c_context.get_default_metric() == "MAU"
+    
+    def test_to_yaml_dict(self):
+        """Test YAML serialization."""
+        context = Context(
+            company=CompanyContext(
+                name="YAML Co",
+                type="b2b",
+                stage="seed",
+                domain="yaml.com"
+            ),
+            product=ProductContext(
+                name="YAML Product",
+                description="Product for YAML testing"
+            )
+        )
+        
+        yaml_dict = context.to_yaml_dict()
+        
+        # Check structure
+        assert "company" in yaml_dict
+        assert "product" in yaml_dict
+        assert yaml_dict["company"]["name"] == "YAML Co"
+        assert yaml_dict["company"]["domain"] == "yaml.com"
+        
+        # Check None values are excluded
+        assert "market" not in yaml_dict
+        assert "team" not in yaml_dict
+        assert "okrs" not in yaml_dict


### PR DESCRIPTION
## Summary
- Implements PMKIT-015: Define context Pydantic models
- Implements PMKIT-016: Complete team and OKR models with confidence scoring
- Creates lean, PM-focused models without overengineering

## Changes Made

### Context Models (PMKIT-015)
- **CompanyContext**: Essential company info with B2B/B2C differentiation
- **ProductContext**: Product details with smart metric defaults
- **MarketContext**: Competitor tracking and differentiators
- **TeamContext**: Team size and role distribution
- **OKRContext**: Objectives and key results structure

### Confidence Scoring (PMKIT-016)
- Added `confidence` field (0-100%) to KeyResult model
- Added `average_confidence` property to Objective
- Added `at_risk_key_results` property to identify KRs <50% confidence

### Technical Details
- Used Pydantic V2 best practices (ConfigDict, field_validator, model_dump)
- No deprecation warnings
- Minimal fields - each one directly improves PRD quality or saves PM time
- Smart defaults reduce setup friction

## Test Coverage
✅ 23 comprehensive tests all passing
- Model validation tests
- B2B/B2C differentiation tests
- Confidence scoring tests
- At-risk identification tests

## Philosophy
Every field earns its place by directly helping PMs make better decisions or saving time. No enterprise theater, no overengineering.